### PR TITLE
Add field corrections to summarizer

### DIFF
--- a/config/gracc-request.spec
+++ b/config/gracc-request.spec
@@ -1,5 +1,5 @@
 Name:           gracc-request
-Version:        2.2
+Version:        2.3
 Release:        1%{?dist}
 Summary:        GRACC Listener for Raw and Summary Records
 
@@ -71,6 +71,9 @@ install -m 0744 config/graccreq.service $RPM_BUILD_ROOT/%{_unitdir}/
 
 
 %changelog
+* Fri Oct 7 2016 Kevin Retzke <kretzke@fnal.gov> 2.3-1
+- Add name corrections
+
 * Fri Sep 23 2016 Derek Weitzel <dweitzel@cse.unl.edu> 2.2-1
 - Dramatically improve OIM Topology performance
 

--- a/config/gracc-request.toml
+++ b/config/gracc-request.toml
@@ -12,4 +12,19 @@ exchange = 'gracc.osg.requests'
 queue = 'gracc.osg.requests'
 
 [ElasticSearch]
+uri = 'http://localhost:9200'
 raw_index = 'gracc.osg.raw0-*'
+
+[[Corrections]]
+index = 'gracc.corrections'
+doc_type = 'vo'
+match_fields = ['VOName','ReportableVOName']
+source_field = 'CorrectedVOName'
+dest_field = 'VOName'
+
+[[Corrections]]
+index = 'gracc.corrections'
+doc_type = 'project'
+match_fields = ['ProjectName']
+source_field = 'CorrectedProjectName'
+dest_field = 'ProjectName'

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,13 @@ import os
 
 
 setup(name='graccreq',
-      version='2.2',
+      version='2.3',
       description='GRACC Request Daemon',
       author_email='dweitzel@cse.unl.edu',
       author='Derek Weitzel',
       url='https://opensciencegrid.github.io/gracc',
       package_dir={'': 'src'},
-      packages=['graccreq', 'graccreq.oim'],
+      packages=['graccreq', 'graccreq.oim', 'graccreq.correct'],
       install_requires=['elasticsearch',
       'elasticsearch-dsl',
       'pika',

--- a/src/graccreq/correct/__init__.py
+++ b/src/graccreq/correct/__init__.py
@@ -1,0 +1,1 @@
+from .correct import Corrections

--- a/src/graccreq/correct/correct.py
+++ b/src/graccreq/correct/correct.py
@@ -9,7 +9,7 @@ class Corrections:
     """
     Generic class for correcting fields based on lookup to Elasticseearch table.
 
-    The corrections are fetched when the class is instantiated and cached. Call
+    The corrections are fetched and cached when the class is instantiated. Call
     fetch_corrections() to refresh the cache.
     """
     def __init__(self, uri, index, doc_type, match_fields, source_field, dest_field):

--- a/src/graccreq/correct/correct.py
+++ b/src/graccreq/correct/correct.py
@@ -1,0 +1,62 @@
+import logging
+from elasticsearch import Elasticsearch
+from elasticsearch.helpers import scan
+from elasticsearch.exceptions import ElasticsearchException
+
+logger = logging.getLogger(__name__)
+
+class Corrections:
+    def __init__(self, elasticsearch_uri, index):
+        self.vos = {}
+        self.projects = {}
+        try:
+            client = Elasticsearch(elasticsearch_uri, timeout=300)
+            s = scan(client=client, index=index, scroll='10m')
+            for doc in s:
+                type = doc.get('_type')
+                source = doc.get('_source',{})
+                if type == 'vo' \
+                   and 'VOName' in source \
+                   and 'ReportableVOName' in source \
+                   and 'CorrectedVOName' in source:
+                    self.vos[str(source['VOName'])+str(source['ReportableVOName'])] = source['CorrectedVOName']
+                elif type == 'project' \
+                     and 'ProjectName' in source \
+                     and 'CorrectedProjectName' in source:
+                    self.projects[str(source['ProjectName'])] = source['CorrectedProjectName']
+        except ElasticsearchException as e:
+            logger.error('unable to fetch corrections: {}'.format(e))
+        else:
+            logger.info('loaded {} vo and {} project name corrections from {}/{}'.
+                        format(len(self.vos),
+                               len(self.projects),
+                               elasticsearch_uri,
+                               index))
+
+    def correct_vo(self, vo_name, reportable_vo_name):
+        """
+        Returns corrected VO name, or vo_name if there is no correction.
+        """
+        return self.vos.get(str(vo_name)+str(reportable_vo_name), vo_name)
+
+    def correct_project(self, project_name):
+        """
+        Returns corrected project name, or project_name if there is no correction.
+        """
+        return self.projects.get(str(project_name), project_name)
+
+    def correct(self, rec):
+        """
+        Corrects fields in the raw JobUsageRecord.
+        """
+        if 'VOName' in rec and 'ReportableVOName' in rec:
+            rec['VOName'] = self.correct_vo(rec['VOName'], rec['ReportableVOName'])
+        if 'ProjectName' in rec:
+            rec['ProjectName'] = self.correct_project(rec['ProjectName'])
+
+if __name__ == '__main__':
+    import urllib3
+    urllib3.disable_warnings()
+    logging.basicConfig(level=logging.INFO)
+    c = NameCorrections(elasticsearch_uri = 'https://gracc.opensciencegrid.org/q',
+                        index = 'gracc.corrections')

--- a/src/graccreq/correct/correct.py
+++ b/src/graccreq/correct/correct.py
@@ -86,12 +86,12 @@ class Corrections:
         :param dict rec: record document
         :return dict: record document
         """
+        rec['Raw'+self.dest_field] = rec.get(self.dest_field,'')
         for field in self.match_fields:
             if field not in rec:
                 return rec
         key = self._key(rec)
         if key in self.corrections:
-            rec['Raw'+self.dest_field] = rec[self.dest_field]
             rec[self.dest_field] = self.corrections[key]
         return rec
 

--- a/src/graccreq/summary_replayer.py
+++ b/src/graccreq/summary_replayer.py
@@ -10,6 +10,7 @@ import dateutil
 import copy
 import datetime
 from graccreq.oim import projects, OIMTopology
+from graccreq.correct import Corrections
 
 
 def SummaryReplayerFactory(msg, parameters, config):
@@ -32,6 +33,16 @@ class SummaryReplayer(replayer.Replayer):
 
         # Initialize the OIM Topology information
         self.topology = OIMTopology.OIMTopology()
+
+        # Initiatlize name corrections
+        self.corrections = []
+        for c in self._config.get('Corrections',[]):
+            self.corrections.append(Corrections(uri=self._config['ElasticSearch'].get('uri','http://localhost:9200'),
+                                                index=c['index'],
+                                                doc_type=c['doc_type'],
+                                                match_fields=c['match_fields'],
+                                                source_field=c['source_field'],
+                                                dest_field=c['dest_field']))
         
     def run(self):
         logging.debug("Beggining run of SummaryReplayer")
@@ -46,6 +57,8 @@ class SummaryReplayer(replayer.Replayer):
         try:
             for day in self._queryElasticsearch(self.msg['from'], self.msg['to'], None):
                 for record in day:
+                    for c in self.corrections:
+                        c.correct(record)
                     self.addProperties(record)
                     self.sendMessage(json.dumps(record))
         except Exception, e:
@@ -61,7 +74,7 @@ class SummaryReplayer(replayer.Replayer):
 
     def on_return(self, channel, method, properties, body):
         sys.stderr.write("Got returned message\n")
-        
+
     def addProperties(self, record):
 
         returned_doc = self.project.parseDoc(record)

--- a/tests/unittests/test_correct.py
+++ b/tests/unittests/test_correct.py
@@ -1,0 +1,54 @@
+import unittest
+
+from graccreq.correct import Corrections
+
+class MockCorrections(Corrections):
+    def __init__(self):
+        self.corrections = {}
+        self.match_fields = []
+        self.dest_field = ''
+
+class TestCorrections(unittest.TestCase):
+    def test_simple_corrections(self):
+        c = MockCorrections()
+        c.match_fields=['name']
+        c.source_field='corrected_name'
+        c.dest_field='name'
+        c._add_correction({'_source':{'name':'foo','corrected_name':'FOO'}})
+        c._add_correction({'_source':{'name':'bar','corrected_name':'BAR'}})
+
+        doc = c.correct({'name':'foo'})
+        self.assertEqual(doc['name'],'FOO')
+        self.assertEqual(doc['Rawname'],'foo')
+
+        doc = {'name': 'bar'}
+        c.correct(doc)
+        self.assertEqual(doc['name'],'BAR')
+        self.assertEqual(doc['Rawname'],'bar')
+
+        return True
+
+    def test_complex_corrections(self):
+        c = MockCorrections()
+        c.match_fields=['name','type']
+        c.source_field='corrected_name'
+        c.dest_field='name'
+        c._add_correction({'_source':{'name':'foo','type':'baz','corrected_name':'FOO'}})
+        c._add_correction({'_source':{'name':'bar','type':'baz','corrected_name':'BAR'}})
+        c._add_correction({'_source':{'name':'bar','type':'qux','corrected_name':'NOTBAR'}})
+
+        doc = c.correct({'name':'foo','type':'baz'})
+        self.assertEqual(doc['name'],'FOO')
+        self.assertEqual(doc['Rawname'],'foo')
+
+        doc = {'name': 'bar','type':'baz'}
+        c.correct(doc)
+        self.assertEqual(doc['name'],'BAR')
+        self.assertEqual(doc['Rawname'],'bar')
+
+        doc = {'name': 'bar','type':'bux'}
+        c.correct(doc)
+        self.assertEqual(doc['name'],'bar')
+        self.assertEqual(doc['Rawname'],'bar')
+
+        return True


### PR DESCRIPTION
Add a configurable module to lookup field corrections from Elasticsearch, supporting multiple field matches (e.g. correct `VOName` based on both `VOName` and `ReportableVOName` fields). Original field values are saved in a new field named `Raw<fieldname>` (e.g. `RawVOName`).

Also adds a `uri` parameter in the `[ElasticSearch]` configuration section to use Elasticsearch servers not on `localhost:9200`, but does not include changes to use this parameter elsewhere in the agent.
