### PR TITLE
Oim topology name corrections

### DIFF
--- a/src/graccreq/oim/OIMTopology.py
+++ b/src/graccreq/oim/OIMTopology.py
@@ -89,15 +89,15 @@ class OIMTopology(object):
 
         # This could (and probably should) be moved to a config file
         rg_pathdictionary = {
-            'Facility': './Facility/Name',
-            'Site': './Site/Name',
-            'ResourceGroup': './GroupName'}
+            'OIMFacility': './Facility/Name',
+            'OIMSite': './Site/Name',
+            'OIMResourceGroup': './GroupName'}
 
         r_pathdictionary = {
-            'Resource': './Name',
-            'ID': './ID',
-            'FQDN': './FQDN',
-            'WLCGAccountingName': './WLCGInformation/AccountingName'
+            'OIMResource': './Name',
+            'OIMID': './ID',
+            'OIMFQDN': './FQDN',
+            'OIMWLCGAccountingName': './WLCGInformation/AccountingName'
         }
 
         returndict = {}
@@ -196,7 +196,7 @@ class OIMTopology(object):
             return {}
 
         for resourcename, resourcedict in self.resourcedict.iteritems():
-            if 'FQDN' in resourcedict and resourcedict['FQDN'] == fqdn:
+            if 'OIMFQDN' in resourcedict and resourcedict['OIMFQDN'] == fqdn:
                 return resourcedict
         else:
             return {}
@@ -215,9 +215,9 @@ class OIMTopology(object):
 
         returndict = {}
         for resourcename, resourcedict in self.resourcedict.iteritems():
-            if 'Site' in resourcedict and resourcedict['Site'] == sitename:
-                returndict['Site'] = resourcedict['Site']
-                returndict['Facility'] = resourcedict['Facility']
+            if 'OIMSite' in resourcedict and resourcedict['OIMSite'] == sitename:
+                returndict['OIMSite'] = resourcedict['OIMSite']
+                returndict['OIMFacility'] = resourcedict['OIMFacility']
         return returndict
 
     def get_information_by_resourcegroup(self, rgname):
@@ -234,11 +234,11 @@ class OIMTopology(object):
 
         returndict = {}
         for resourcename, resourcedict in self.resourcedict.iteritems():
-            if 'ResourceGroup' in resourcedict and \
-                            resourcedict['ResourceGroup'] == rgname:
-                returndict['Site'] = resourcedict['Site']
-                returndict['Facility'] = resourcedict['Facility']
-                returndict['ResourceGroup'] = resourcedict['ResourceGroup']
+            if 'OIMResourceGroup' in resourcedict and \
+                            resourcedict['OIMResourceGroup'] == rgname:
+                returndict['OIMSite'] = resourcedict['OIMSite']
+                returndict['OIMFacility'] = resourcedict['OIMFacility']
+                returndict['OIMResourceGroup'] = resourcedict['OIMResourceGroup']
         return returndict
 
     def check_hostdescription(self, doc):
@@ -338,7 +338,7 @@ class OIMTopology(object):
         returndict = rawdict.copy()
 
         if 'VOOwnership' in returndict:
-            returndict['UsageModel'] = self.check_VO(doc, rawdict)
+            returndict['OIMUsageModel'] = self.check_VO(doc, rawdict)
 
         keys_to_delete = ['Contacts', 'VOOwnership', 'ID']
         # Delete unnecessary keys

--- a/tests/unittests/test_OIMTopology.py
+++ b/tests/unittests/test_OIMTopology.py
@@ -13,20 +13,20 @@ class BasicOIMTopologyTests(unittest.TestCase):
     def test_fqdn(self):
         """OIMTopology match by gracc probe to topology FQDN"""
         testdict = self.topology.get_information_by_fqdn('fifebatch1.fnal.gov')
-        self.assertEqual(testdict['Facility'], 'Fermi National Accelerator'
+        self.assertEqual(testdict['OIMFacility'], 'Fermi National Accelerator'
                                                ' Laboratory')
-        self.assertEqual(testdict['Site'], 'FermiGrid')
-        self.assertEqual(testdict['ResourceGroup'], 'FNAL_FIFE_SUBMIT')
-        self.assertEqual(testdict['Resource'],'FIFE_SUBMIT_1')
+        self.assertEqual(testdict['OIMSite'], 'FermiGrid')
+        self.assertEqual(testdict['OIMResourceGroup'], 'FNAL_FIFE_SUBMIT')
+        self.assertEqual(testdict['OIMResource'],'FIFE_SUBMIT_1')
         return True
 
     def test_resource(self):
         """OIMTopology match by gracc SiteName to topology resource"""
         testdict = self.topology.get_information_by_resource('AGLT2_SL6')
-        self.assertEqual(testdict['Facility'], 'University of Michigan')
-        self.assertEqual(testdict['Site'], 'AGLT2')
-        self.assertEqual(testdict['ResourceGroup'], 'AGLT2')
-        self.assertEqual(testdict['Resource'],'AGLT2_SL6')
+        self.assertEqual(testdict['OIMFacility'], 'University of Michigan')
+        self.assertEqual(testdict['OIMSite'], 'AGLT2')
+        self.assertEqual(testdict['OIMResourceGroup'], 'AGLT2')
+        self.assertEqual(testdict['OIMResource'],'AGLT2_SL6')
         return True
 
 
@@ -81,22 +81,22 @@ class GRACCDictTests(BasicOIMTopologyTests):
         """Matching by probename, so the incorrect SiteName should be
         ignored"""
         ded = self.topology.generate_dict_for_gracc(self.testdoc_ded)
-        self.assertEqual(ded['Facility'], 'University of Michigan')
-        self.assertEqual(ded['Site'], 'AGLT2')
-        self.assertEqual(ded['ResourceGroup'], 'AGLT2')
-        self.assertEqual(ded['Resource'],'AGLT2_CE_2')
-        self.assertEqual(ded['UsageModel'], 'DEDICATED')
+        self.assertEqual(ded['OIMFacility'], 'University of Michigan')
+        self.assertEqual(ded['OIMSite'], 'AGLT2')
+        self.assertEqual(ded['OIMResourceGroup'], 'AGLT2')
+        self.assertEqual(ded['OIMResource'],'AGLT2_CE_2')
+        self.assertEqual(ded['OIMUsageModel'], 'DEDICATED')
         return True
 
     def test_opportunistic(self):
         """Matching by probename, so the incorrect SiteName should be
         ignored"""
         op = self.topology.generate_dict_for_gracc(self.testdoc_op)
-        self.assertEqual(op['Facility'], 'University of Michigan')
-        self.assertEqual(op['Site'], 'AGLT2')
-        self.assertEqual(op['ResourceGroup'], 'AGLT2')
-        self.assertEqual(op['Resource'], 'AGLT2_CE_2')
-        self.assertEqual(op['UsageModel'], 'OPPORTUNISTIC')
+        self.assertEqual(op['OIMFacility'], 'University of Michigan')
+        self.assertEqual(op['OIMSite'], 'AGLT2')
+        self.assertEqual(op['OIMResourceGroup'], 'AGLT2')
+        self.assertEqual(op['OIMResource'], 'AGLT2_CE_2')
+        self.assertEqual(op['OIMUsageModel'], 'OPPORTUNISTIC')
         return True
 
     def test_fallbacktosite(self):
@@ -104,12 +104,12 @@ class GRACCDictTests(BasicOIMTopologyTests):
         Group"""
         fail_probe = self.topology.generate_dict_for_gracc(
             self.testdoc_fail_probe)
-        self.assertEqual(fail_probe['Facility'], 'University of Michigan')
-        self.assertEqual(fail_probe['Site'], 'AGLT2')
-        self.assertEqual(fail_probe['ResourceGroup'], 'AGLT2')
-        self.assertNotEqual(fail_probe['Resource'],'AGLT2_CE_2')
-        self.assertEqual(fail_probe['Resource'],'AGLT2_SL6')
-        self.assertEqual(fail_probe['UsageModel'], 'OPPORTUNISTIC')
+        self.assertEqual(fail_probe['OIMFacility'], 'University of Michigan')
+        self.assertEqual(fail_probe['OIMSite'], 'AGLT2')
+        self.assertEqual(fail_probe['OIMResourceGroup'], 'AGLT2')
+        self.assertNotEqual(fail_probe['OIMResource'],'AGLT2_CE_2')
+        self.assertEqual(fail_probe['OIMResource'],'AGLT2_SL6')
+        self.assertEqual(fail_probe['OIMUsageModel'], 'OPPORTUNISTIC')
         return True
     
     def test_fail(self):
@@ -123,12 +123,12 @@ class GRACCDictTests(BasicOIMTopologyTests):
         """No Probe name in gracc doc at all"""
         fail_probe = self.topology.generate_dict_for_gracc(
             self.testdoc_noprobe)
-        self.assertEqual(fail_probe['Facility'], 'University of Michigan')
-        self.assertEqual(fail_probe['Site'], 'AGLT2')
-        self.assertEqual(fail_probe['ResourceGroup'], 'AGLT2')
-        self.assertNotEqual(fail_probe['Resource'],'AGLT2_CE_2')
-        self.assertEqual(fail_probe['Resource'],'AGLT2_SL6')
-        self.assertEqual(fail_probe['UsageModel'], 'OPPORTUNISTIC')
+        self.assertEqual(fail_probe['OIMFacility'], 'University of Michigan')
+        self.assertEqual(fail_probe['OIMSite'], 'AGLT2')
+        self.assertEqual(fail_probe['OIMResourceGroup'], 'AGLT2')
+        self.assertNotEqual(fail_probe['OIMResource'],'AGLT2_CE_2')
+        self.assertEqual(fail_probe['OIMResource'],'AGLT2_SL6')
+        self.assertEqual(fail_probe['OIMUsageModel'], 'OPPORTUNISTIC')
         return True
 
     def test_noprobe_nosite(self):
@@ -140,28 +140,28 @@ class GRACCDictTests(BasicOIMTopologyTests):
     def test_no_vo(self):
         fail_probe = self.topology.generate_dict_for_gracc(
             self.testdoc_no_vo)
-        self.assertEqual(fail_probe['UsageModel'], 'UNKNOWN')
+        self.assertEqual(fail_probe['OIMUsageModel'], 'UNKNOWN')
         return True
 
     def test_payload(self):
         """Payload record - should be successful match for BNL_ATLAS_1
         resource"""
         pg = self.topology.generate_dict_for_gracc(self.testdoc_payload_suc)
-        self.assertEqual(pg['Facility'], 'Brookhaven National Laboratory')
-        self.assertEqual(pg['Site'], 'Brookhaven ATLAS Tier1')
-        self.assertEqual(pg['ResourceGroup'], 'BNL-ATLAS')
-        self.assertEqual(pg['Resource'], 'BNL_ATLAS_1')
-        self.assertEqual(pg['UsageModel'], 'DEDICATED')
+        self.assertEqual(pg['OIMFacility'], 'Brookhaven National Laboratory')
+        self.assertEqual(pg['OIMSite'], 'Brookhaven ATLAS Tier1')
+        self.assertEqual(pg['OIMResourceGroup'], 'BNL-ATLAS')
+        self.assertEqual(pg['OIMResource'], 'BNL_ATLAS_1')
+        self.assertEqual(pg['OIMUsageModel'], 'DEDICATED')
         return True
 
     def test_payload_site(self):
         """Payload record - should be successful match for UConn-OSG Site"""
         st = self.topology.generate_dict_for_gracc(self.testdoc_payload_site)
-        self.assertEqual(st['Facility'], 'University of Connecticut')
-        self.assertEqual(st['Site'], 'UConn-OSG')
-        rg = st.get('ResourceGroup')
-        res = st.get('Resource')
-        um = st.get('UsageModel')
+        self.assertEqual(st['OIMFacility'], 'University of Connecticut')
+        self.assertEqual(st['OIMSite'], 'UConn-OSG')
+        rg = st.get('OIMResourceGroup')
+        res = st.get('OIMResource')
+        um = st.get('OIMUsageModel')
         self.assertFalse(rg)
         self.assertFalse(res)
         self.assertFalse(um)
@@ -171,11 +171,11 @@ class GRACCDictTests(BasicOIMTopologyTests):
         """Payload record - should be successful match for Hyak Resource
         Group"""
         rg = self.topology.generate_dict_for_gracc(self.testdoc_payload_rg)
-        self.assertEqual(rg['Facility'], 'University of Washington')
-        self.assertEqual(rg['Site'], 'UW-IT')
-        self.assertEqual(rg['ResourceGroup'], 'Hyak')
-        res = rg.get('Resource')
-        um = rg.get('UsageModel')
+        self.assertEqual(rg['OIMFacility'], 'University of Washington')
+        self.assertEqual(rg['OIMSite'], 'UW-IT')
+        self.assertEqual(rg['OIMResourceGroup'], 'Hyak')
+        res = rg.get('OIMResource')
+        um = rg.get('OIMUsageModel')
         self.assertFalse(res)
         self.assertFalse(um)
         return True


### PR DESCRIPTION
This is for GRACC-28.  I just added "OIM" to the beginning of all of the fields OIMTopology.py returns.