### PR TITLE
OIMTopology OIM_Match field

### DIFF
--- a/src/graccreq/oim/OIMTopology.py
+++ b/src/graccreq/oim/OIMTopology.py
@@ -236,11 +236,28 @@ class OIMTopology(object):
 
     @staticmethod
     def add_matched_to(indict, level):
+        """Add information to instance copy of resource dict that indicates
+        at which level (resource, resource group, etc.) in the resource dict a
+        GRACC entry was matched.
+
+        For example, if we're matching the GRACC record to the resource dict
+        Resource, this will add "Resource" as a value to the "OIM_Match" key
+
+        Returns the dictionary indict with the added OIM_Match: value pair."""
         indict['OIM_Match'] = level
         return indict
 
     @staticmethod
     def add_matched_from(indict, level):
+        """Similar to add_matched_to, this adds information to the instance
+         copy of resource dict as to what field in the GRACC record was used
+         to match.
+
+         For example, if we use the Host_description from the GRACC record
+         and match that to the Resource in the resource dict, this will set the
+         value of OIM_Match to "Host_description-Resource"
+
+         Returns the dictionary indict with the amended OIM_Match: value pair"""
         indict['OIM_Match'] = '{0}-{1}'.format(level, indict['OIM_Match'])
         return indict
 
@@ -251,7 +268,10 @@ class OIMTopology(object):
         Arguments:
             resourcename (string) - Resource Name
 
-        Returns: Dictionary that has relevant OIM information
+        Returns: Dictionary that has relevant OIM information.
+
+        Note:  We wrap the return statement in the self.add_matched_to call so
+        that the dict returned has the OIM_Match field as well.
         """
         if not self.have_info:
             return {}
@@ -269,7 +289,11 @@ class OIMTopology(object):
         Arguments:
             fqdn (string) - FQDN of the resource
 
-        Returns: Dictionary that has relevant OIM information"""
+        Returns: Dictionary that has relevant OIM information
+
+        Note:  We wrap the return statement in the self.add_matched_to call so
+        that the dict returned has the OIM_Match field as well.
+        """
         if not self.have_info:
             return {}
 
@@ -287,6 +311,9 @@ class OIMTopology(object):
             sitename (string) - Site Name
 
         Returns: Dictionary that has relevant OIM information
+
+        Note:  We wrap the return statement in the self.add_matched_to call so
+        that the dict returned has the OIM_Match field as well.
         """
         if not self.have_info:
             return {}
@@ -309,6 +336,9 @@ class OIMTopology(object):
             rgname (string) - Resource Name
 
         Returns: Dictionary that has relevant OIM information
+
+        Note:  We wrap the return statement in the self.add_matched_to call so
+        that the dict returned has the OIM_Match field as well.
         """
         if not self.have_info:
             return {}

--- a/src/graccreq/oim/OIMTopology.py
+++ b/src/graccreq/oim/OIMTopology.py
@@ -236,12 +236,12 @@ class OIMTopology(object):
 
     @staticmethod
     def add_matched_to(indict, level):
-        indict["OIM_Match"] = level
+        indict['OIM_Match'] = level
         return indict
 
     @staticmethod
     def add_matched_from(indict, level):
-        indict["OIM_Match"] = '{0}-{1}'.format(level, indict["OIM_Match"])
+        indict['OIM_Match'] = '{0}-{1}'.format(level, indict['OIM_Match'])
         return indict
 
     def get_information_by_resource(self, resourcename):
@@ -257,7 +257,6 @@ class OIMTopology(object):
             return {}
         
         if resourcename in self.resourcedict:
-            # return self.resourcedict[resourcename]
             return self.add_matched_to(self.resourcedict[resourcename],
                                        'Resource')
         else:
@@ -277,7 +276,6 @@ class OIMTopology(object):
         for resourcename, rdict in self.resourcedict.iteritems():
             if 'OIM_FQDN' in rdict and rdict['OIM_FQDN'] == fqdn:
                 return self.add_matched_to(rdict, 'FQDN')
-                # return resourcedict
         else:
             return {}
 
@@ -298,7 +296,10 @@ class OIMTopology(object):
             if 'OIM_Site' in rdict and rdict['OIM_Site'] == sitename:
                 returndict['OIM_Site'] = rdict['OIM_Site']
                 returndict['OIM_Facility'] = rdict['OIM_Facility']
-        return self.add_matched_to(returndict, 'Site')
+        if returndict:
+            return self.add_matched_to(returndict, 'Site')
+        else:
+            return {}
 
     def get_information_by_resourcegroup(self, rgname):
         """Gets the relevant information from the parsed OIM XML file based on
@@ -319,7 +320,10 @@ class OIMTopology(object):
                 returndict['OIM_Site'] = rdict['OIM_Site']
                 returndict['OIM_Facility'] = rdict['OIM_Facility']
                 returndict['OIM_ResourceGroup'] = rdict['OIM_ResourceGroup']
-        return self.add_matched_to(returndict, 'Resource Group')
+        if returndict:
+            return self.add_matched_to(returndict, 'ResourceGroup')
+        else:
+            return {}
 
     def check_hostdescription(self, doc):
         """Matches host description to resource name, site name, or resource
@@ -341,9 +345,11 @@ class OIMTopology(object):
         if not returndict:
             returndict = \
                 self.get_information_by_resourcegroup(doc['Host_description'])
+
         if returndict:
-            returndict = self.add_matched_from(returndict, 'Host_description')
-        return returndict
+            return self.add_matched_from(returndict, 'Host_description')
+        else:
+            return {}
 
     def check_probe(self, doc):
         """Gets information from OIM based on the probe name passed in
@@ -358,7 +364,8 @@ class OIMTopology(object):
         if probe_fqdn_check:
             probe_fqdn = probe_fqdn_check.group(1)
             returndict = self.get_information_by_fqdn(probe_fqdn)
-            return self.add_matched_from(returndict, 'ProbeName')
+            if returndict:
+                return self.add_matched_from(returndict, 'ProbeName')
         else:
             return {}
 
@@ -372,7 +379,10 @@ class OIMTopology(object):
          dictionary if a match was not found
         """
         returndict = self.get_information_by_resource(doc['SiteName'])
-        return self.add_matched_from(returndict, 'SiteName')
+        if returndict:
+            return self.add_matched_from(returndict, 'SiteName')
+        else:
+            return {}
 
     @staticmethod
     def check_VO(doc, rdict):

--- a/tests/unittests/test_OIMTopology.py
+++ b/tests/unittests/test_OIMTopology.py
@@ -19,6 +19,7 @@ class BasicOIMTopologyTests(unittest.TestCase):
         self.assertEqual(testdict['OIM_Site'], 'FermiGrid')
         self.assertEqual(testdict['OIM_ResourceGroup'], 'FNAL_FIFE_SUBMIT')
         self.assertEqual(testdict['OIM_Resource'],'FIFE_SUBMIT_1')
+        self.assertEqual(testdict['OIM_Match'], 'FQDN')
         return True
 
     def test_resource(self):
@@ -29,6 +30,7 @@ class BasicOIMTopologyTests(unittest.TestCase):
         self.assertEqual(testdict['OIM_ResourceGroup'], 'AGLT2')
         self.assertEqual(testdict['OIM_Resource'],'AGLT2_SL6')
         self.assertEqual(testdict['OIM_WLCGAPELNormalFactor'], 10.16)
+        self.assertEqual(testdict['OIM_Match'], 'Resource')
         return True
 
     @classmethod
@@ -105,6 +107,7 @@ class GRACCDictTests(BasicOIMTopologyTests):
         self.assertEqual(ded['OIM_ResourceGroup'], 'AGLT2')
         self.assertEqual(ded['OIM_Resource'],'AGLT2_CE_2')
         self.assertEqual(ded['OIM_UsageModel'], 'DEDICATED')
+        self.assertEqual(ded['OIM_Match'], 'ProbeName-FQDN')
         return True
 
     def test_opportunistic(self):
@@ -116,6 +119,7 @@ class GRACCDictTests(BasicOIMTopologyTests):
         self.assertEqual(op['OIM_ResourceGroup'], 'AGLT2')
         self.assertEqual(op['OIM_Resource'], 'AGLT2_CE_2')
         self.assertEqual(op['OIM_UsageModel'], 'OPPORTUNISTIC')
+        self.assertEqual(op['OIM_Match'], 'ProbeName-FQDN')
         return True
 
     def test_fallbacktosite(self):
@@ -129,6 +133,7 @@ class GRACCDictTests(BasicOIMTopologyTests):
         self.assertNotEqual(fail_probe['OIM_Resource'],'AGLT2_CE_2')
         self.assertEqual(fail_probe['OIM_Resource'],'AGLT2_SL6')
         self.assertEqual(fail_probe['OIM_UsageModel'], 'OPPORTUNISTIC')
+        self.assertEqual(fail_probe['OIM_Match'], 'SiteName-Resource')
         return True
     
     def test_fail(self):
@@ -148,6 +153,7 @@ class GRACCDictTests(BasicOIMTopologyTests):
         self.assertNotEqual(fail_probe['OIM_Resource'],'AGLT2_CE_2')
         self.assertEqual(fail_probe['OIM_Resource'],'AGLT2_SL6')
         self.assertEqual(fail_probe['OIM_UsageModel'], 'OPPORTUNISTIC')
+        self.assertEqual(fail_probe['OIM_Match'], 'SiteName-Resource')
         return True
 
     def test_noprobe_nosite(self):
@@ -171,6 +177,7 @@ class GRACCDictTests(BasicOIMTopologyTests):
         self.assertEqual(pg['OIM_ResourceGroup'], 'BNL-ATLAS')
         self.assertEqual(pg['OIM_Resource'], 'BNL_ATLAS_1')
         self.assertEqual(pg['OIM_UsageModel'], 'DEDICATED')
+        self.assertEqual(pg['OIM_Match'], 'Host_description-Resource')
         return True
 
     def test_payload_site(self):
@@ -184,6 +191,7 @@ class GRACCDictTests(BasicOIMTopologyTests):
         self.assertFalse(rg)
         self.assertFalse(res)
         self.assertFalse(um)
+        self.assertEqual(st['OIM_Match'],'Host_description-Site')
         return True
 
     def test_payload_rg(self):
@@ -197,6 +205,7 @@ class GRACCDictTests(BasicOIMTopologyTests):
         um = rg.get('OIM_UsageModel')
         self.assertFalse(res)
         self.assertFalse(um)
+        self.assertEqual(rg['OIM_Match'], 'Host_description-ResourceGroup')
         return True
     
     def test_payload_fail(self):


### PR DESCRIPTION
This is for GRACC-48.  The new OIM_Match field shows what was matched from the GRACC raw record, and what level it was matched at to an OIM entry (Resource, ResourceGroup, Site, etc.).