### PR TITLE
Bug fix for cache file

### DIFF
--- a/src/graccreq/oim/OIMTopology.py
+++ b/src/graccreq/oim/OIMTopology.py
@@ -11,7 +11,6 @@ import logging
 SEC_IN_DAY = 86400
 cachefile = '/tmp/resourcedict.pickle'
 lockfile = '/tmp/lockfile_OIM_cache'
-curtime = int(time.time())
 
 
 class OIMTopology(object):
@@ -54,6 +53,7 @@ class OIMTopology(object):
         """Method to unpickle resourcedict from cache.
         Returns True on success, False otherwise"""
         # We check that the cachefile exists and is less than 1 day old
+        curtime = int(time.time())
         if os.path.exists(cachefile):
             if curtime - int(os.path.getmtime(cachefile)) < SEC_IN_DAY:
                 try:


### PR DESCRIPTION
When deciding whether or not to create a new Cache file for OIM Topology, the current time used to be evaluated when the module itself was loaded, not when the OIMTopology class was instantiated.  Therefore, as long as a worker was alive, the cachefile didn't get updated. I moved the evaluation of the time (variable curtime) into the function within OIMTopology called read_from_cache, where we decide whether or not to read the currently-stored cache file.

If this passes unit tests, we should probably deploy this as soon as possible - it's a pretty important oversight that's completely on me.