### PR TITLE
Get OIM VO FOS information for Non-payload jobs

### DIFF
--- a/src/graccreq/oim/voinfo.py
+++ b/src/graccreq/oim/voinfo.py
@@ -107,7 +107,7 @@ class OIMVOInfo(object):
         :return dict doc:  GRACC record with OIM_FOS either added or corrected
         """
         if 'ResourceType' in doc and doc['ResourceType'] != 'Payload':
-            if 'VOName' in doc:
+            if 'VOName' in doc and doc['VOName'].lower() in self.vodict:
                 newfos = self.vodict[doc['VOName'].lower()]['PrimaryFields']
                 doc['OIM_FieldOfScience'] = newfos
                 logging.info('Set FOS to {0}'.format(newfos))

--- a/src/graccreq/oim/voinfo.py
+++ b/src/graccreq/oim/voinfo.py
@@ -102,13 +102,29 @@ class OIMVOInfo(object):
         """
         if 'ResourceType' in doc and doc['ResourceType'] != 'Payload':
             if 'VOName' in doc:
-                doc['OIM_FieldofScience'] = self.vodict[doc['VOName'].lower()]['PrimaryFields']
+                doc['OIM_FieldOfScience'] = self.vodict[doc['VOName'].lower()]['PrimaryFields']
 
         return doc
 
 
 if __name__ == '__main__':
     x = OIMVOInfo()
-    # print x.vodict
-    testdoc = {'VOName':'osg', 'ResourceType':'Batch'}
-    print x.parse_doc(testdoc)
+    testdoc = {
+        "ResourceType": "Batch",
+        "VOName": "atlas",
+        "RawProjectName": "N/A",
+        "ProjectName": "N/A",
+        }
+    print x.parse_doc(testdoc)['OIM_FieldOfScience']  # Should be HEP
+    testdoc2 = {
+        "OIM_Organization": "Georgia Institute of Technology",
+        "ResourceType": "Batch",
+        "VOName": "osg",
+        "RawProjectName": "VERITAS",
+        "OIM_Department": "School of Physics & Center for Relativistic Astrophysics",
+        "ReportableVOName": "osg",
+        "RawVOName": "/osg/LocalGroup=users",
+        "ProjectName": "VERITAS",
+        "OIM_FieldOfScience": "Astrophysics",
+        }
+    print x.parse_doc(testdoc2)['OIM_FieldOfScience']   # Should be Multi-Science Community from OSG VO

--- a/src/graccreq/oim/voinfo.py
+++ b/src/graccreq/oim/voinfo.py
@@ -103,8 +103,8 @@ class OIMVOInfo(object):
         Parse corrected raw non-Payload doc, write VO FOS into the 
         OIM_FieldofScience field.
         
-        :param dict doc:
-        :return: 
+        :param dict doc: GRACC Record
+        :return dict doc:  GRACC record with OIM_FOS either added or corrected
         """
         if 'ResourceType' in doc and doc['ResourceType'] != 'Payload':
             if 'VOName' in doc:

--- a/src/graccreq/oim/voinfo.py
+++ b/src/graccreq/oim/voinfo.py
@@ -1,0 +1,79 @@
+import xml.etree.ElementTree as ET
+import urllib2
+import logging
+import re
+from copy import deepcopy
+
+
+VOURL = "https://myosg.grid.iu.edu/vosummary/xml?summary_attrs_showfield_of_science=on&all_vos=on&active=on&active_value=1&oasis_value=1&sort_key=name"
+
+class OIMVOInfo(object):
+    wanted_attributes = {'FieldsOfScience':{'PrimaryFields': 'Field', 'SecondaryFields': 'Field'}}
+    vodict = {}
+
+    def __init__(self):
+        self.xmlfile = self.__get_oim_info()
+        self.__get_vo_info()
+
+
+    def __get_oim_info(self):
+        try:
+            oim_xml = urllib2.urlopen(VOURL)
+        except (urllib2.HTTPError, urllib2.URLError) as e:
+            logging.error(e)
+            return None
+        return oim_xml
+
+    def __get_vo_info(self):
+        pathattr = re.compile('.//.+/(\w+)/.+')
+
+        root = ET.parse(self.xmlfile)
+        root = root.getroot()
+
+        for voelt in root:
+            VOName = voelt.find('Name').text
+            if VOName not in self.vodict:
+                self.vodict[VOName] = {}
+            cur_dict = self.vodict[VOName]
+
+            xpath_list_raw = []
+
+            def recurse_attrs(cur_level, curlist):
+                if not isinstance(cur_level, dict):
+                    curlist.append(cur_level)
+                    xpath_list_raw.append(curlist)
+                else:
+                    for key in cur_level:
+                        nowlist = deepcopy(curlist)
+                        nowlist.append(key)
+                        recurse_attrs(cur_level[key], nowlist)
+
+            recurse_attrs(self.wanted_attributes, [])
+
+            xpaths = []
+            for pathlist in xpath_list_raw:
+                path = './/' + '/'.join(pathlist)
+                xpaths.append(path)
+
+
+            for path in xpaths:
+                m = pathattr.match(path)
+                if m:
+                    key = m.group(1)
+                lst = []
+                for elt in voelt.findall(path):
+                    lst.append(elt.text)
+
+                if len(lst) != 0:
+                    cur_dict[key] = lst
+
+        return
+
+    def parse_doc(self):
+        # Parse doc, if anything to update, then do it.
+        pass
+
+
+if __name__ == '__main__':
+    x = OIMVOInfo()
+    print x.vodict

--- a/src/graccreq/oim/voinfo.py
+++ b/src/graccreq/oim/voinfo.py
@@ -8,15 +8,29 @@ from copy import deepcopy
 VOURL = "https://myosg.grid.iu.edu/vosummary/xml?summary_attrs_showfield_of_science=on&all_vos=on&active=on&active_value=1&oasis_value=1&sort_key=name"
 
 class OIMVOInfo(object):
-    wanted_attributes = {'FieldsOfScience':{'PrimaryFields': 'Field', 'SecondaryFields': 'Field'}}
+    """
+    
+    """
+    # Put any non-nested element before the last item in this list.  The last
+    # item is a dict that holds all nested elements and the structure
+    wanted_attributes = ['LongName', 'Name',        # These two are examples - we don't actually need them
+                         {'FieldsOfScience':        # We actually want these
+                              {'PrimaryFields': 'Field',
+                               'SecondaryFields': 'Field'
+                               }
+                          }
+                         ]
     vodict = {}
 
     def __init__(self):
         self.xmlfile = self.__get_oim_info()
         self.__get_vo_info()
 
-
     def __get_oim_info(self):
+        """
+        
+        :return: 
+        """
         try:
             oim_xml = urllib2.urlopen(VOURL)
         except (urllib2.HTTPError, urllib2.URLError) as e:
@@ -25,55 +39,76 @@ class OIMVOInfo(object):
         return oim_xml
 
     def __get_vo_info(self):
-        pathattr = re.compile('.//.+/(\w+)/.+')
+        """
+        
+        :return: 
+        """
+        pathattr = re.compile('^.//(\w+)$')     # Top level elements
+        pathattr_rec = re.compile('^.//.+/(\w+)/.+$')   # Nested Elements
 
         root = ET.parse(self.xmlfile)
         root = root.getroot()
 
         for voelt in root:
-            VOName = voelt.find('Name').text
+            VOName = voelt.find('Name').text.lower()
             if VOName not in self.vodict:
                 self.vodict[VOName] = {}
             cur_dict = self.vodict[VOName]
 
-            xpath_list_raw = []
+            # Top level xpaths
+            xpaths = ['.//' + attr for attr in self.wanted_attributes[:-1]]
 
-            def recurse_attrs(cur_level, curlist):
+            # Nested xpaths
+            def recurse_attrs(cur_level, cur_list=[], final_list=[]):
                 if not isinstance(cur_level, dict):
-                    curlist.append(cur_level)
-                    xpath_list_raw.append(curlist)
+                    cur_list.append(cur_level)
+                    final_list.append(cur_list)
                 else:
                     for key in cur_level:
-                        nowlist = deepcopy(curlist)
+                        nowlist = deepcopy(cur_list)
                         nowlist.append(key)
-                        recurse_attrs(cur_level[key], nowlist)
+                        recurse_attrs(cur_level[key], nowlist, final_list)
+                return final_list
 
-            recurse_attrs(self.wanted_attributes, [])
+            xpath_list_raw = recurse_attrs(self.wanted_attributes[-1])
 
-            xpaths = []
-            for pathlist in xpath_list_raw:
-                path = './/' + '/'.join(pathlist)
-                xpaths.append(path)
+            xpaths.extend(['.//' + '/'.join(pathlist)
+                           for pathlist in xpath_list_raw])
 
-
+            # Look for info in XML file
             for path in xpaths:
-                m = pathattr.match(path)
+                m = filter(None, (pat.match(path) for pat in (pathattr, pathattr_rec)))
+                assert len(m) == 1  # One or other should be a match, not both
                 if m:
-                    key = m.group(1)
-                lst = []
-                for elt in voelt.findall(path):
-                    lst.append(elt.text)
+                    key = m[0].group(1)
+                else:
+                    continue    # Skip this key
+                lst = [elt.text for elt in voelt.findall(path)] # Search XML file using xpath
 
-                if len(lst) != 0:
-                    cur_dict[key] = lst
+                if len(lst) > 1:
+                    cur_dict[key] = lst  # Add to dict
+                elif len(lst) == 1:
+                    cur_dict[key] = lst[0]
 
         return
 
-    def parse_doc(self):
-        # Parse doc, if anything to update, then do it.
-        pass
+    def parse_doc(self, doc):
+        """
+        Parse corrected raw non-Payload doc, write VO FOS into the 
+        OIM_FieldofScience field.
+        
+        :param dict doc:
+        :return: 
+        """
+        if 'ResourceType' in doc and doc['ResourceType'] != 'Payload':
+            if 'VOName' in doc:
+                doc['OIM_FieldofScience'] = self.vodict[doc['VOName'].lower()]['PrimaryFields']
+
+        return doc
 
 
 if __name__ == '__main__':
     x = OIMVOInfo()
-    print x.vodict
+    # print x.vodict
+    testdoc = {'VOName':'osg', 'ResourceType':'Batch'}
+    print x.parse_doc(testdoc)

--- a/src/graccreq/oim/voinfo.py
+++ b/src/graccreq/oim/voinfo.py
@@ -34,6 +34,7 @@ class OIMVOInfo(object):
         """
         try:
             oim_xml = urllib2.urlopen(VOURL)
+            logging.info('Downloaded OIM VO info')
         except (urllib2.HTTPError, urllib2.URLError) as e:
             logging.error(e)
             return None
@@ -94,6 +95,7 @@ class OIMVOInfo(object):
                 elif len(lst) == 1:
                     cur_dict[key] = lst[0]
 
+        logging.info('Constructed OIM VO dictionary')
         return
 
     def parse_doc(self, doc):
@@ -106,6 +108,7 @@ class OIMVOInfo(object):
         """
         if 'ResourceType' in doc and doc['ResourceType'] != 'Payload':
             if 'VOName' in doc:
-                doc['OIM_FieldOfScience'] = self.vodict[doc['VOName'].lower()]['PrimaryFields']
-
+                newfos = self.vodict[doc['VOName'].lower()]['PrimaryFields']
+                doc['OIM_FieldOfScience'] = newfos
+                logging.info('Set FOS to {0}'.format(newfos))
         return doc

--- a/src/graccreq/summary_replayer.py
+++ b/src/graccreq/summary_replayer.py
@@ -102,7 +102,6 @@ class SummaryReplayer(replayer.Replayer):
         sys.stderr.write("Got returned message\n")
 
     def addProperties(self, record):
-
         returned_doc = self.project.parseDoc(record)
         topology_doc = self.topology.generate_dict_for_gracc(record)
         vo_doc = self.oimvoinfo.parse_doc(record)

--- a/src/graccreq/summary_replayer.py
+++ b/src/graccreq/summary_replayer.py
@@ -10,7 +10,7 @@ import replayer
 import dateutil
 import copy
 import datetime
-from graccreq.oim import projects, OIMTopology
+from graccreq.oim import projects, OIMTopology, voinfo
 import StringIO
 from graccreq.correct import Corrections
 
@@ -54,6 +54,9 @@ class SummaryReplayer(replayer.Replayer):
 
         # Initialize the OIM Topology information
         self.topology = OIMTopology.OIMTopology()
+
+        # Initialize the OIM VO information
+        self.oimvoinfo = voinfo.OIMVOInfo()
 
         # Initiatlize name corrections
         self.corrections = []
@@ -102,10 +105,11 @@ class SummaryReplayer(replayer.Replayer):
 
         returned_doc = self.project.parseDoc(record)
         topology_doc = self.topology.generate_dict_for_gracc(record)
+        vo_doc = self.oimvoinfo.parse_doc(record)
         record.update(returned_doc)
         record.update(topology_doc)
+        record.update(vo_doc)
         return record
-        
         
     def _queryElasticsearch(self, from_date, to_date, query):
         logging.debug("Connecting to ES")

--- a/tests/unittests/test_OIMVOInfo.py
+++ b/tests/unittests/test_OIMVOInfo.py
@@ -1,0 +1,44 @@
+import unittest
+
+from graccreq.oim import voinfo
+
+class TestOIMVOInfo(unittest.TestCase):
+    """Unit tests for OIM VO Info module"""
+
+    def setUp(self):
+        self.v = voinfo.OIMVOInfo()
+
+    def test_no_overwrite(self):
+        testdoc = {
+            "ResourceType": "Batch",
+            "VOName": "atlas",
+            "RawProjectName": "N/A",
+            "ProjectName": "N/A",
+        }
+        retdoc = self.v.parse_doc(testdoc)
+        self.assertEqual(retdoc['OIM_FieldOfScience'], 'High Energy Physics')
+        self.assertEqual(testdoc, retdoc)
+        return True
+
+    def test_override(self):
+        testdoc = {
+            "OIM_Organization": "Georgia Institute of Technology",
+            "ResourceType": "Batch",
+            "VOName": "osg",
+            "RawProjectName": "VERITAS",
+            "OIM_Department": "School of Physics & Center for Relativistic Astrophysics",
+            "ReportableVOName": "osg",
+            "RawVOName": "/osg/LocalGroup=users",
+            "ProjectName": "VERITAS",
+            "OIM_FieldOfScience": "Astrophysics",
+        }
+        retdoc = self.v.parse_doc(testdoc)
+        self.assertEqual(retdoc['OIM_FieldOfScience'], 'Multi-Science Community')
+
+        for key in testdoc.iterkeys():
+            if key != 'OIM_FieldOfScience':
+                self.assertEqual(testdoc[key], retdoc[key])
+        return True
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
We take the gracc VO-corrected raw record, and if it's not a Payload record, overwrite the OIM_FieldOfScience if it exists and is different from the OIM VO info or add it in if it doesn't. 